### PR TITLE
Allow for static_info_tables 6.x

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -22,7 +22,7 @@ $EM_CONF[$_EXTKEY] = [
     'constraints' => [
         'depends' => [
             'typo3' => '8.7.0-9.5.99',
-            'static_info_tables' => '6.7.3-6.7.99',
+            'static_info_tables' => '6.7.3-6.9.99',
         ],
         'conflicts' => [],
         'suggests' => [],


### PR DESCRIPTION
Raising the restriction allows for installation with static_info_tables 6.8, which provides PHP 7.4.

See here: https://github.com/manuelselbach/static_info_tables/commits/6.8.0